### PR TITLE
Proofreading fixes

### DIFF
--- a/src/epub/text/act-2.xhtml
+++ b/src/epub/text/act-2.xhtml
@@ -261,7 +261,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Bezano</td>
-						<td><i epub:type="z3998:stage-direction">Entering.</i> Consuelo, where are you? I have been looking for you⁠—come on. <i epub:type="z3998:stage-direction">Both go out. The <b epub:type="z3998:persona">Baron</b>, after hesitating a while, follows them.<b epub:type="z3998:persona">Mancini</b> accompanies him respectfully to the door.</i></td>
+						<td><i epub:type="z3998:stage-direction">Entering.</i> Consuelo, where are you? I have been looking for you⁠—come on. <i epub:type="z3998:stage-direction">Both go out. The <b epub:type="z3998:persona">Baron</b>, after hesitating a while, follows them. <b epub:type="z3998:persona">Mancini</b> accompanies him respectfully to the door.</i></td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">He</td>

--- a/src/epub/text/act-2.xhtml
+++ b/src/epub/text/act-2.xhtml
@@ -69,7 +69,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Consuelo</td>
-						<td>Yes, very much. He is so good-looking. He says that Bezano and I are the most beautiful couple in the world. <b>He</b> calls him Adam, and me Eve. But that’s improper, isn’t it? <b>He</b> is <em>so</em> improper.</td>
+						<td>Yes, very much. He is so good-looking. <b>He</b> says that Bezano and I are the most beautiful couple in the world. <b>He</b> calls him Adam, and me Eve. But that’s improper, isn’t it? <b>He</b> is <em>so</em> improper.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Baron</td>

--- a/src/epub/text/act-2.xhtml
+++ b/src/epub/text/act-2.xhtml
@@ -169,7 +169,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Mancini</td>
-						<td><i epub:type="z3998:stage-direction">Shaking hands.</i> What a success, Baron⁠—and think of it⁠—how the crowd does love slaps. <i epub:type="z3998:stage-direction">Whispering.</i> Your knees are dusty, Baron, brush them off. The floor is very dirty in here. <i epub:type="z3998:stage-direction">Aloud.</i> Consuelo, dear child, how do you feel? <i epub:type="z3998:stage-direction">Goes over to his daughter. Sound of laughing, chattering. The waiters from the buffet in the lobby bring in soda and wine. Consuelo’s voice it heard.</i></td>
+						<td><i epub:type="z3998:stage-direction">Shaking hands.</i> What a success, Baron⁠—and think of it⁠—how the crowd does love slaps. <i epub:type="z3998:stage-direction">Whispering.</i> Your knees are dusty, Baron, brush them off. The floor is very dirty in here. <i epub:type="z3998:stage-direction">Aloud.</i> Consuelo, dear child, how do you feel? <i epub:type="z3998:stage-direction">Goes over to his daughter. Sound of laughing, chattering. The waiters from the buffet in the lobby bring in soda and wine. Consuelo’s voice is heard.</i></td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Consuelo</td>

--- a/src/epub/text/act-4.xhtml
+++ b/src/epub/text/act-4.xhtml
@@ -224,7 +224,7 @@
 					<tr>
 						<td/>
 						<td>
-							<i epub:type="z3998:stage-direction">Enter <b epub:type="z3998:persona">Briquet</b> and <b epub:type="z3998:persona">Mancini</b>. The latter it reserved, and self-consciously imposing. He has a new suit, but the same cane, and the same noiseless smile of a satyr.</i>
+							<i epub:type="z3998:stage-direction">Enter <b epub:type="z3998:persona">Briquet</b> and <b epub:type="z3998:persona">Mancini</b>. The latter is reserved, and self-consciously imposing. He has a new suit, but the same cane, and the same noiseless smile of a satyr.</i>
 						</td>
 					</tr>
 					<tr>


### PR DESCRIPTION
A few typos and one editorial fix here. The editorial change was a usage of `He` which from context refers to the title character, not a generic pronoun, and should therefore appear in small caps. This doesn't appear in small caps in the scans, so I marked it [Editorial].